### PR TITLE
Make "Search Key" name consistent

### DIFF
--- a/keysearch-extension/Info.plist
+++ b/keysearch-extension/Info.plist
@@ -39,7 +39,7 @@
 			<key>Image</key>
 			<string>ToolbarItemIcon.png</string>
 			<key>Label</key>
-			<string>Your Button</string>
+			<string>Search Key</string>
 		</dict>
 		<key>SFSafariWebsiteAccess</key>
 		<dict>

--- a/keysearch-extension/Info.plist
+++ b/keysearch-extension/Info.plist
@@ -5,7 +5,7 @@
 	<key>CFBundleDevelopmentRegion</key>
 	<string>$(DEVELOPMENT_LANGUAGE)</string>
 	<key>CFBundleDisplayName</key>
-	<string>keysearch</string>
+	<string>Search Key</string>
 	<key>CFBundleExecutable</key>
 	<string>$(EXECUTABLE_NAME)</string>
 	<key>CFBundleIdentifier</key>


### PR DESCRIPTION
Updated bundle display name and label key to "Search Key" to match App Store listing (changes name in Safari preferences as well as tooltip on Safari toolbar)